### PR TITLE
Fix the imports from Docker to Mirantis

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/educlos/testrail"
 	"github.com/urfave/cli"
 
-	"github.com/docker/trailer/spec"
+	"github.com/Mirantis/trailer/spec"
 )
 
 type Suite struct {


### PR DESCRIPTION
Go can not actually build the binary when the imports point to Docker,
so switch the imports to be Mirantis.

Signed-off-by: Jose Bigio <jose.bigio@docker.com>